### PR TITLE
Add home vue features.

### DIFF
--- a/resources/bi.json
+++ b/resources/bi.json
@@ -1,0 +1,43 @@
+[
+    {
+        "manufacturer": "ST",
+        "boards": [
+            {
+                "name": "stm32f407-rt-spark",
+                "description" : "RT-Thread官方的星火一号开发板，基于STM32F407",
+                "board": "stm32f407-rt-spark",
+                "path": "bsp/stm32/stm32f407-rt-spark"
+        
+            },
+            {
+                "name": "stm32f412-st-nucleo",
+                "description": "ST官方的STM32F412 Nucleo开发板",
+                "board": "stm32f412-st-nucleo",
+                "path":"bsp/stm32/stm32f412-st-nucleo"
+            }
+        ]
+    },
+    {
+        "manufacturer": "QEMU",
+        "boards": [
+            {
+                "name": "qemu-vexpress-a9",
+                "description": "VExpress A9评估板卡，可以使用QEMU ARM来模拟ARM Cortex-A 32位系列机器",
+                "board": "qemu-vexpress-a9",
+                "path": "bsp/qemu-vexpress-a9"        
+            },
+            {
+                "name": "qemu-virt64-aarch64",
+                "description": "QEMU模拟的virt aarch64机器",
+                "board": "qemu-virt64-aarch64",
+                "path": "bsp/qemu-virt64-aarch64"
+            },
+            {
+                "name": "qemu-virt64-riscv64",
+                "description": "QEMU模拟的virt riscv64机器",
+                "board": "qemu-virt64-riscv64",
+                "path": "bsp/qemu-virt64-riscv64"
+            }
+        ]
+    }
+]

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,165 @@
+import * as vscode from 'vscode';
+
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import { executeCommand } from './terminal';
+
+let _context: vscode.ExtensionContext;
+let _isRTThread = false;
+let _bi: any[] = [];
+
+export function isRTThreadProject() {
+    return _isRTThread;
+}
+
+export function initAPI(context:vscode.ExtensionContext, isRTThreadEnv: boolean) {
+    _context = context;
+    _isRTThread = isRTThreadEnv;
+
+    // read resources/bi.json for boards information
+    _bi = readJsonObject(path.join(getExtensionPath(), "resources", "bi.json"));
+}
+
+export function getBoardInfo(): any {
+    let bi = [];
+
+    for (const item of _bi) {
+        let vendor = { manufacturer : item.manufacturer, boards : [] as string[]};
+
+        for (const board of item.boards) {
+            let name:string = board.board;
+
+            vendor.boards.push(name);
+        }
+        bi.push(vendor);
+    }
+
+    return bi;
+}
+
+export function getBoardPath(name:string):string {
+    for (const item of _bi) {
+        for (const board of item.boards) {
+            if (board.board === name) {
+                return board.path;
+            }
+        }
+    }
+
+    return "";
+}
+
+export function getEnvROOT() {
+    // return vscode.workspace.getConfiguration('smart').get('envROOT');
+    return path.join(os.homedir(), '.env');
+}
+
+export function getRTTRoot() {
+    const cfgFn = path.join(os.homedir(), '.env/cfg.json');
+    let cfg = readJsonObject(cfgFn);
+    if (cfg.length > 0) {
+        for (const item of cfg) {
+            if (item.name === "RT-Thread") {
+                return item.path;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+/*
+ projectInfo {
+    name,
+    folder,
+    cpu,
+    bsp, 
+    linkRTT,
+    linkDriver
+ }
+*/
+export function createProject(folder: string, projectInfo: any) {
+    let project_path = path.join(folder, projectInfo.name);
+
+    if (fs.existsSync(project_path)) {
+        vscode.window.showWarningMessage('Project folder already exists.');
+        return ;
+    }
+    else {
+        let RTTRoot = getRTTRoot();
+        if (RTTRoot) {
+            // try to create project
+            let bsp_path = path.join(RTTRoot, getBoardPath(projectInfo.board));
+            let cmd:string = `scons --dist --project-name=${projectInfo.name} --project-path=${project_path} -C ${bsp_path}`;
+
+            executeCommand(cmd);
+        }
+        else {
+            vscode.window.showErrorMessage("No RT-Thread Root found. Please set it.");
+        }
+    }
+
+    return ;
+}
+
+export function getExtensionVersion() {
+    return _context.extension.packageJSON.version;
+}
+
+export function getExtensionPath() {
+    return _context.extensionPath;
+}
+
+export function getWorkspaceFolder() {
+    return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
+export function installEnv(folder: string) {
+    if (fs.existsSync(folder)) {
+        vscode.window.showWarningMessage('env already exists.');
+        return ;
+    }
+
+    return ;
+}
+
+export function readJsonObject(fn: string) {
+    if (fs.existsSync(fn)) {
+        let data = fs.readFileSync(fn, 'utf-8');
+        return JSON.parse(data);
+    }
+
+    return [];
+}
+
+export function writeJsonObject(jsonObject: any, fn:string) {
+    const jsonContent = JSON.stringify(jsonObject, null, 4);
+    fs.writeFileSync(fn, jsonContent, 'utf-8');
+
+    return ;
+}
+
+export async function openFolder(uri?: string) {
+    let selectedFolder:vscode.Uri[] | undefined;
+
+    if (uri != undefined) {
+        selectedFolder = await vscode.window.showOpenDialog({
+            defaultUri: vscode.Uri.file(uri),
+            canSelectFolders: true,
+            canSelectFiles: false,
+            canSelectMany: false,
+          });      
+    }
+    else {
+        selectedFolder = await vscode.window.showOpenDialog({
+            canSelectFolders: true,
+            canSelectFiles: false,
+            canSelectMany: false,
+          });      
+    }
+
+    if (selectedFolder && selectedFolder.length > 0) {
+      return selectedFolder[0].fsPath;
+    }
+}

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import * as vscode from 'vscode';
 import os from 'os';
 import fs from 'fs';
-import { isRTThreadProject, getWorkspaceFolder } from './extension';
+import { getWorkspaceFolder, isRTThreadProject } from './api';
 import { buildGroupsTree, buildProjectTree, buildEmptyProjectTree, ProjectTreeItem, listFolderTreeItem } from './project/tree';
 import { cmds } from './cmds/index';
 
@@ -13,11 +13,17 @@ class CmdTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
 
     getChildren(element?: vscode.TreeItem): vscode.ProviderResult<vscode.TreeItem[]> {
         if (isRTThreadProject() != true) {
-            let noProject = new vscode.TreeItem("Not a RT-Thread Project");
-            noProject.iconPath = new vscode.ThemeIcon("warning");
-            noProject.label = "Not a RT-Thread Project";
+            // only show Home command
+            let home = new vscode.TreeItem("Home", vscode.TreeItemCollapsibleState.None);
+            home.iconPath = new vscode.ThemeIcon("home");
+            home.label = "Home";
+            home.command = {
+                command: "extension.showHome",
+                title: "show home page",
+                arguments: [],
+            };
 
-            return [noProject];
+            return [home];
         }
 
         if (!element) {

--- a/src/project/tree.ts
+++ b/src/project/tree.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import * as vscode from 'vscode';
 import os, { getPriority } from 'os';
 import fs from 'fs';
-import { getWorkspaceFolder, getExtensionPath } from '../extension';
+import { getWorkspaceFolder, getExtensionPath } from '../api';
 
 /*
  * contexType -> contextValue as following value:

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { getExtensionPath, getWorkspaceFolder } from './extension';
+import { getExtensionPath, getWorkspaceFolder } from './api';
 import { Constants } from './constants';
 
 let _terminal: vscode.Terminal | undefined;

--- a/src/vue/home/App.vue
+++ b/src/vue/home/App.vue
@@ -1,17 +1,64 @@
 <template>
-    <div class="container">
-      <img class="logo_img" :src="imgUrl['head-logo']" alt="" />
-      <h1>Home</h1>
+    <div>
+        <router-view></router-view>
     </div>
-  </template>
-  
-  <script setup lang="ts">
-  import { imgUrl } from '../assets/img';
-  </script>
-  
-  <style scoped>
-  .container {
-    padding: 20px;
-  }
-  </style>
-  
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUpdated, ref } from 'vue';
+import { extensionInfo, projectInfo, envInfo, configInfo } from "./data";
+import { sendCommand } from '../api/vscode';
+
+onUpdated(() => {
+    console.log('App updated');
+});
+
+onMounted(() => {
+    sendCommand('getExtensionInfo');
+    window.addEventListener('message', event => {
+        const message = event.data;
+        // console.log(message);
+
+        switch (message.command) {
+            case 'extensionInfo':
+                extensionInfo.value.version = message.data.version;
+                projectInfo.value.projectList = message.data.projectList;
+
+                envInfo.value.version = message.data.env.version;
+                envInfo.value.path = message.data.env.path;
+                envInfo.value.environmentData = message.data.SDKConfig;
+                configInfo.value.configData = message.data.configInfo;
+                break;
+
+            case 'setToolchainFolder':
+                // message like {command: 'setToolchainFolder', data: 'path'}
+                envInfo.value.addToolchain.path = message.data;
+                break;
+
+            case 'setItemFolder':
+                // message like {command: 'setItemFolder', data: 'path'}
+                configInfo.value.editConfigItem.path = message.data;
+                break;
+
+            case 'setProjectFolder':
+                // message like {command: 'setProjectFolder', data: 'path'}
+                projectInfo.value.folder = message.data;
+                break;
+
+            case 'setSDKConfig':
+                envInfo.value.environmentData = message.data;
+                break;
+
+            default:
+                break;
+        }
+    });
+});
+
+</script>
+<style>
+* {
+    margin: 0;
+    padding: 0;
+}
+</style>

--- a/src/vue/home/data.ts
+++ b/src/vue/home/data.ts
@@ -1,0 +1,165 @@
+import { ref } from 'vue';
+
+// data model
+export let extensionInfo = ref<any>({
+    envRoot: "~/.env",
+    version: "0.4.11"
+});
+
+export let projectInfo = ref<any>({
+    folder: "",
+    name: "",
+    board: "",
+    manufacturer: "",
+    projectList: [
+        {
+            manufacturer: "stm32",
+            boards: [
+                "stm32f407-rt-spark"
+            ],
+        },
+        {
+            manufacturer: "qemu",
+            boards: [
+                "qemu-vexpress-a9"
+            ]
+        }
+    ],
+    linkRTT: false,
+    linkDriver: false,
+    readme: "README.md"
+});
+
+export const analysisInfo = ref<any>({
+    mapFile: "rt-thread.map",
+    mapFileUrl: "",
+    analysisTableList: [
+        {
+            title: "全部符号",
+            children: [
+                {
+                    name: "name01",
+                    path: "0x00",
+                    size: "12",
+                },
+                {
+                    name: "name02",
+                    path: "0x20",
+                    size: "16",
+                },
+            ]
+        },
+        {
+            title: "按文件",
+            children: [
+                {
+                    name: "file01",
+                    path: "0x00",
+                    size: "12",
+                },
+                {
+                    name: "file02",
+                    path: "0x20",
+                    size: "16",
+                },
+            ]
+        },
+        {
+            title: "按Groups",
+            children: [
+                {
+                    name: "Groups01",
+                    path: "0x00",
+                    size: "12",
+                },
+                {
+                    name: "Groups02",
+                    path: "0x20",
+                    size: "16",
+                },
+            ]
+        }
+    ],
+    analysisTitleList: [
+        {
+            title: "名称",
+            field: "name",
+        },
+        {
+            title: "地址",
+            field: "path",
+        },
+        {
+            title: "大小",
+            field: "size",
+        },
+    ]
+});
+
+export const envInfo = ref<any>({
+    progressNum: 0,
+    selectRow: null,
+
+    version : "v2.0.1",
+    path: "~/.env",
+
+    environmentTitleList: [
+        {
+            title: "名称",
+            field: "name",
+        },
+        {
+            title: "路径",
+            field: "path",
+        },
+        {
+            title: "描述",
+            field: "description",
+        },
+    ],
+    environmentData: [
+        {
+            name: "gcc",
+            path: "d:/tools/toolchains/arm-none-eabi-gcc",
+            description: "ARM GNU GCC",
+        }
+    ],
+    dialogVisible: false,
+    editMode: false,
+    addToolchain: {
+        name: "",
+        path: "",
+        description: ""
+    },
+    radioChange: 0,
+});
+
+export const configInfo = ref<any>({
+    configTitleList: [
+        {
+            title: "名称",
+            field: "name",
+        },
+        {
+            title: "路径",
+            field: "path",
+        },
+        {
+            title: "描述",
+            field: "description",
+        },
+    ],
+    configData: [
+        {
+            name: "RT-Thread",
+            path: "d:/workspace/rt-thread",
+            description: "RT-Thread 主干版本",
+        }
+    ],
+    dialogVisible: false,
+    editConfigItem: {
+        name: "",
+        path: "",
+        description: ""
+    }
+});

--- a/src/vue/home/main.ts
+++ b/src/vue/home/main.ts
@@ -2,7 +2,10 @@ import { createApp } from 'vue'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 import App from './App.vue'
+import router from './router'
 
 const app = createApp(App)
 app.use(ElementPlus)
+app.use(router)
+
 app.mount('#app')

--- a/src/vue/home/router.ts
+++ b/src/vue/home/router.ts
@@ -1,0 +1,85 @@
+import { createRouter, createWebHashHistory } from "vue-router";
+import CreatProject from './view/create-project/index.vue'
+import Environment from './view/environment/index.vue'
+import SymbolicAnalysis from './view/symbolic-analysis/index.vue'
+import Config from './view/config/index.vue'
+import LayoutView from './view/layout/index.vue'
+
+export const routes = [
+    {
+        path: '/',
+        component: LayoutView,
+        meta: {
+            title: '创建工程'
+        },
+        redirect: '/',
+        children: [
+            {
+                path: '/',
+                component: CreatProject,
+                meta: {
+                    title: '创建工程'
+                }
+            },
+        ]
+    },
+    {
+        path: '/environment',
+        component: LayoutView,
+        meta: {
+            title: '环境工具'
+        },
+        redirect: '/environment',
+        children: [
+            {
+                path: '/environment',
+                component: Environment,
+                meta: {
+                    title: '环境工具'
+                },
+            },
+        ]
+    },
+    {
+        path: '/symbolic-analysis',
+        component: LayoutView,
+        meta: {
+            title: '符号分析',
+            hidden: true
+        },
+        redirect: '/symbolic-analysis',
+        children: [
+            {
+                path: '/symbolic-analysis',
+                component: SymbolicAnalysis,
+                meta: {
+                    title: '符号分析',
+                    hidden: true
+                },
+            },
+        ]
+    },
+    {
+        path: '/config',
+        component: LayoutView,
+        meta: {
+            title: '配置'
+        },
+        redirect: '/config',
+        children: [
+            {
+                path: '/config',
+                component: Config,
+                meta: {
+                    title: '配置'
+                },
+            },
+        ]
+    }
+]
+const router = createRouter({
+    history: createWebHashHistory(),
+    routes
+})
+
+export default router

--- a/src/vue/home/view/config/index.less
+++ b/src/vue/home/view/config/index.less
@@ -1,0 +1,74 @@
+.content {
+    width: 100%;
+    height: 100%;
+
+    .body-box {
+        width: 80%;
+        min-width: 800px;
+
+        .title {
+            font-size: 14px;
+            color: #333;
+            margin-bottom: 22px;
+        }
+
+        :deep(.el-table--fit) {
+            border: none;
+
+            .el-table__inner-wrapper:before {
+                width: 0;
+            }
+        }
+
+        .table-box {
+            width: 100%;
+            display: flex;
+            column-gap: 20px;
+            :deep(.el-table tr) {
+                font-size: 14px;
+                color: #333;
+                height: 48px;
+            }
+        }
+
+        .el-button {
+            width: 98px;
+            height: 40px;
+            margin: 0;
+        }
+    }
+    
+    .form-box {
+        width: 100%;
+        margin-bottom: 30px;
+        padding: 24px 24px 0 0;
+        box-sizing: border-box;
+        .file-box {
+            width: 0;
+        }
+        .row-box {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            column-gap: 14px;
+
+            p {
+                width: 109px;
+            }
+        }
+
+        .el-input {
+            height: 40px;
+        }
+
+        :deep(.el-form-item__label) {
+            justify-content: flex-start;
+        }
+    }
+
+    .dialog-footer {
+        display: flex;
+        justify-content: flex-end;
+        column-gap: 14px;
+    }
+}

--- a/src/vue/home/view/config/index.vue
+++ b/src/vue/home/view/config/index.vue
@@ -1,0 +1,111 @@
+<template>
+    <div class="content">
+        <div class="body-box">
+            <div class="title">目录路径</div>
+            <div class="table-box">
+                <el-table @row-click="handleRowClick" highlight-current-row :data="configInfo.configData"
+                    style="width: 100%">
+                    <el-table-column v-for="item in configInfo.configTitleList" :key="item.title" :prop="item.field"
+                        :label="item.title">
+                        <template #default="scope">
+                            <div>
+                                <el-input v-model="scope.row[item.field]" v-if="
+                                    configInfo.editRow &&
+                                    scope.row.id === configInfo.editRow.id && editStatus
+                                "></el-input>
+                                <span v-else>{{ scope.row[item.field] }}</span>
+                            </div>
+                        </template>
+                    </el-table-column>
+                </el-table>
+                <div class="btn-box">
+                    <el-button type="primary" plain @click="editFun">编辑</el-button>
+                </div>
+            </div>
+        </div>
+
+        <el-dialog v-model="configInfo.dialogVisible" width="630">
+            <div class="form-box">
+                <el-form :data="configInfo.editConfigItem" label-width="70">
+                    <el-form-item label="名称">
+                        <div class="row-box">
+                            <el-input disabled v-model="configInfo.editConfigItem.name" placeholder="请输入内容" />
+                        </div>
+                    </el-form-item>
+                    <el-form-item label="路径">
+                        <div class="row-box">
+                            <el-input v-model="configInfo.editConfigItem.path" placeholder="请输入内容" />
+                            <el-button type="primary" plain @click="getItemFolderFunction">浏览</el-button>
+                        </div>
+                    </el-form-item>
+                    <el-form-item label="描述">
+                        <el-input disabled v-model="configInfo.editConfigItem.description" placeholder="请输入内容" />
+                    </el-form-item>
+                </el-form>
+            </div>
+            <template #footer>
+                <div class="dialog-footer">
+                    <el-button type="primary" plain @click="confirmFunction">确定</el-button>
+                    <el-button type="primary" plain @click="configInfo.dialogVisible = false">取消</el-button>
+                </div>
+            </template>
+        </el-dialog>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { configInfo } from "../../data";
+import { sendCommand, sendCommandData, showMessage } from "../../../api/vscode";
+
+let selectIndex = -1;
+
+const handleRowClick = (row: any) => {
+    selectIndex = configInfo.value.configData.indexOf(row)
+};
+
+const editStatus = ref(false)
+const editFun = () => {
+    if (selectIndex != -1) {
+        configInfo.value.editConfigItem.name = configInfo.value.configData[selectIndex].name;
+        configInfo.value.editConfigItem.path = configInfo.value.configData[selectIndex].path;
+        configInfo.value.editConfigItem.description = configInfo.value.configData[selectIndex].description;
+
+        configInfo.value.dialogVisible = true
+    }
+    else {
+        showMessage('请选择编辑项！');
+    }
+};
+
+const getItemFolderFunction = () => {
+    if (configInfo.value.editConfigItem.path) {
+        sendCommandData("browseItemFolder", configInfo.value.editConfigItem.path);
+    }
+    else {
+        sendCommandData("browseItemFolder", {});
+    }
+};
+
+const confirmFunction = () => {
+    if (selectIndex != -1) {
+        let item = {
+            name: configInfo.value.editConfigItem.name, 
+            path: configInfo.value.editConfigItem.path, 
+            description: configInfo.value.editConfigItem.description
+        };
+
+        configInfo.value.configData[selectIndex].name = configInfo.value.editConfigItem.name;
+        configInfo.value.configData[selectIndex].path = configInfo.value.editConfigItem.path;
+        configInfo.value.configData[selectIndex].description = configInfo.value.editConfigItem.description;
+
+        sendCommand("setConfig", [[item]]);
+    }
+
+    configInfo.value.dialogVisible = false;
+};
+
+</script>
+<style scoped>
+@import "./index.less";
+</style>

--- a/src/vue/home/view/create-project/index.less
+++ b/src/vue/home/view/create-project/index.less
@@ -1,0 +1,51 @@
+.content {
+    width: 100%;
+    height: 100%;
+
+    .body-box {
+        width: 80%;
+        min-width: 800px;
+
+        .el-form {
+            :deep(.el-form-item__label) {
+                justify-content: flex-start;
+            }
+            .file-box {
+                width: 0;
+            }
+
+            .el-input {
+                height: 40px;
+            }
+
+            .el-form-item {
+                display: flex;
+                align-items: center;
+            }
+
+            .row-box {
+                width: 100%;
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                column-gap: 20px;
+            }
+
+            :deep(.el-checkbox) {
+                margin-right: 0;
+            }
+
+        }
+
+        .iframe-box {
+            width: 100%;
+            height:auto;
+        }
+    }
+
+    .el-button {
+        width: 98px;
+        height: 40px;
+        margin: 0;
+    }
+}

--- a/src/vue/home/view/create-project/index.vue
+++ b/src/vue/home/view/create-project/index.vue
@@ -1,0 +1,111 @@
+<template>
+    <div class="content">
+        <div class="body-box">
+            <el-form :model="projectInfo" label-width="120">
+                <el-form-item label="工程名称">
+                    <div class="row-box">
+                        <el-input v-model="projectInfo.name" placeholder="请输入内容" />
+                    </div>
+                </el-form-item>
+                <el-form-item label="空间路径">
+                    <div class="row-box">
+                        <el-input v-model="projectInfo.folder" placeholder="请输入内容" />
+                        <el-button type="primary" plain @click="getProjectFolderFunction">浏览</el-button>
+                    </div>
+                </el-form-item>
+                <el-form-item label="RT-Thread 基线">
+                    <div class="row-box">
+                        <el-select style="width: 40%" v-model="projectInfo.manufacturer" placeholder="请选择"
+                            @change="vendorChanged">
+                            <el-option v-for="item in projectInfo.projectList" :key="item.manufacturer" :label="item.manufacturer"
+                                :value="item.manufacturer" />
+                        </el-select>
+                        <el-select style="width: 50%" v-model="projectInfo.board" placeholder="请选择"
+                            @change="boardChanged">
+                            <el-option v-for="item in projectInfo.projectList[vendorIndex].boards" :key="item"
+                                :label="item" :value="item" />
+                        </el-select>
+                        <el-button type="primary" plain @click="createProject">创建</el-button>
+                    </div>
+                </el-form-item>
+                <el-form-item label="">
+                    <div class="row-box">
+                        <el-checkbox style="width: 40%" v-model="projectInfo.linkRTT" disabled>链接RT-Thread</el-checkbox>
+                        <el-checkbox style="width: 50%" v-model="projectInfo.linkDriver" disabled>链接驱动</el-checkbox>
+                        <p style="width: 98px"></p>
+                    </div>
+                </el-form-item>
+            </el-form>
+            <div>
+                <h3> 创建工程说明 </h3>
+                请在工程名称中填写名称，它会在工程空间路径中创建这样名称的目录放置新创建的工程。
+                <br><br>
+                ⚠️ 请确保空间路径 + 工程名称的路径不存在；否则创建检查失败。
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from "vue";
+import { projectInfo } from "../../data";
+import { sendCommand, sendCommandData } from "../../../api/vscode";
+
+const vendorIndex = computed(() => {
+    let current = 0;
+    projectInfo.value.projectList.filter((item: any, index: any) => {
+        if (item.manufacturer === projectInfo.value.manufacturer) {
+            current = index;
+        }
+    });
+    return current;
+});
+
+const vendorChanged = () => {
+    let current = 0;
+
+    // 当重新选择vendor时，对board进行重置
+    projectInfo.value.projectList.filter((item: any, index: any) => {
+        if (item.manufacturer === projectInfo.value.manufacturer) {
+            current = index;
+        }
+    });
+
+    if (current === -1) {
+        projectInfo.value.board = "";
+    }
+    else {
+        projectInfo.value.board = projectInfo.value.projectList[current].boards[0];
+    }
+
+    // sendCommandData("getBoardReadme", {manufacturer: projectInfo.value.manufacturer, board: projectInfo.value.board});
+};
+
+const getProjectFolderFunction = () => {
+    sendCommandData("browseProjectFolder", projectInfo.value.folder);
+}
+
+// 当选择board时，展示对应目录下的README.md文件
+const boardChanged = () => {
+}
+
+const createProject = () => {
+    let project = {name: "", folder: "", board: "", manufacturer: "", linkRTT: false, linkDriver: false};
+
+    project.name = projectInfo.value.name;
+    project.folder = projectInfo.value.folder;
+    project.board = projectInfo.value.board;
+    project.manufacturer  = projectInfo.value.manufacturer;
+    project.linkRTT = projectInfo.value.linkRTT;
+    project.linkDriver = projectInfo.value.linkDriver;
+
+    sendCommand("createProject", [project]);
+}
+
+onMounted(async () => {
+});
+
+</script>
+<style scoped>
+@import "./index.less";
+</style>

--- a/src/vue/home/view/environment/index.less
+++ b/src/vue/home/view/environment/index.less
@@ -1,0 +1,128 @@
+.content {
+    width: 100%;
+    height: 100%;
+
+    .body-box {
+        width: 80%;
+        min-width: 800px;
+
+        .info-box {
+            display: flex;
+            justify-content: space-between;
+            font-size: 14px;
+            color: #333;
+            margin-bottom: 28px;
+
+            .info-left {
+                width: 80%;
+                padding-top: 10px;
+
+                .info-content {
+                    display: flex;
+                    margin-bottom: 6px;
+
+                    p {
+                        width: 84px;
+                    }
+
+                    .info-text {
+                        display: flex;
+                        flex-direction: column;
+                        row-gap: 4px;
+                        list-style: none;
+                    }
+                }
+
+                .progress-box {
+                    width: 100%;
+                    display: flex;
+                    flex-direction: column;
+
+                    :deep(.el-progress__text) {
+                        color: #333;
+                    }
+                }
+            }
+        }
+    }
+
+    .bottom-box {
+        width: 100%;
+
+        .title {
+            font-size: 14px;
+            color: #333;
+            margin-bottom: 22px;
+        }
+
+        :deep(.el-table--fit) {
+            border: none;
+
+            .el-table__inner-wrapper:before {
+                width: 0;
+            }
+        }
+
+        .table-box {
+            width: 100%;
+            display: flex;
+            column-gap: 20px;
+            .el-radio-group {
+                width: 100%;
+            }
+            :deep(.el-table tr) {
+                font-size: 14px;
+                color: #333;
+                height: 48px;
+            }
+
+            .btn-box {
+                width: 98px;
+                display: flex;
+                flex-direction: column;
+                row-gap: 25px;
+                margin-top: 40px;
+            }
+        }
+    }
+
+    .el-button {
+        width: 98px;
+        height: 40px;
+        margin: 0;
+    }
+
+    .form-box {
+        width: 100%;
+        margin-bottom: 30px;
+        padding: 24px 24px 0 0;
+        box-sizing: border-box;
+        .file-box {
+            width: 0;
+        }
+        .row-box {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            column-gap: 14px;
+
+            p {
+                width: 109px;
+            }
+        }
+
+        .el-input {
+            height: 40px;
+        }
+
+        :deep(.el-form-item__label) {
+            justify-content: flex-start;
+        }
+    }
+
+    .dialog-footer {
+        display: flex;
+        justify-content: flex-end;
+        column-gap: 14px;
+    }
+}

--- a/src/vue/home/view/environment/index.vue
+++ b/src/vue/home/view/environment/index.vue
@@ -1,0 +1,162 @@
+<template>
+    <div class="content">
+        <div class="body-box">
+            <div class="info-box">
+                <div class="info-left">
+                    <div class="info-content">
+                        <p>env信息：</p>
+                        <ul class="info-text">
+                            <li> 版本 {{ envInfo.version }} </li>
+                            <li> 安装路径 {{ envInfo.path }} </li>
+                        </ul>
+                    </div>
+                    <div class="progress-box" v-if="isInstalling">
+                        <p>安装信息...</p>
+                        <el-progress :percentage="envInfo.progressNum" />
+                    </div>
+                </div>
+                <el-button type="primary" plain :disabled="installButtonDisabled" @click="installEnv">安装</el-button>
+            </div>
+            <div class="bottom-box">
+                <div class="title">指定工具链情况</div>
+                <div class="table-box">
+                    <el-table @current-change="handleCurrentChange" highlight-current-row
+                        :data="envInfo.environmentData" style="width: 100%">
+                        <el-table-column v-for="item in envInfo.environmentTitleList" :key="item.title"
+                            :prop="item.field" :label="item.title" />
+                    </el-table>
+                    <div class="btn-box">
+                        <el-button type="primary" plain @click="addFun">添加</el-button>
+                        <el-button type="primary" plain @click="deleteFun">删除</el-button>
+                        <br>
+                        <el-button type="primary" plain @click="editFun">编辑</el-button>
+                        <el-button type="primary" plain @click="saveFun">保存</el-button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <el-dialog v-model="envInfo.dialogVisible" width="630">
+            <div class="form-box">
+                <el-form :data="envInfo.addToolchain" label-width="70">
+                    <el-form-item label="名称">
+                        <div class="row-box">
+                            <el-input v-model="envInfo.addToolchain.name" placeholder="请输入内容" />
+                            <p></p>
+                        </div>
+                    </el-form-item>
+                    <el-form-item label="路径">
+                        <div class="row-box">
+                            <el-input v-model="envInfo.addToolchain.path" placeholder="请输入内容" />
+                            <el-button type="primary" plain @click="getToolChainFolderFunction">浏览</el-button>
+                        </div>
+                    </el-form-item>
+                    <el-form-item label="描述">
+                        <el-input v-model="envInfo.addToolchain.description" placeholder="请输入内容" />
+                    </el-form-item>
+                </el-form>
+            </div>
+            <template #footer>
+                <div class="dialog-footer">
+                    <el-button type="primary" plain @click="confirmFun">确定</el-button>
+                    <el-button type="primary" plain @click="envInfo.dialogVisible = false">
+                        取消
+                    </el-button>
+                </div>
+            </template>
+        </el-dialog>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { envInfo } from "../../data";
+import { sendCommand, sendCommandData, showMessage } from "../../../api/vscode"
+
+const installButtonDisabled = ref(true);
+
+const addFun = () => {
+    envInfo.value.addToolchain = {
+        name: "",
+        path: "",
+        description: "",
+    };
+    envInfo.value.editMode = false;
+    envInfo.value.dialogVisible = true;
+};
+
+const deleteFun = () => {
+    if (envInfo.value.selectRow != null) {
+        let envData = envInfo.value.environmentData;
+        let value = envInfo.value.selectRow;
+        if (value.name) {
+            envInfo.value.environmentData = envData.filter(
+                (key: any) => key != value
+            );
+        }
+
+        envInfo.value.selectRow = null;
+    }
+    else {
+        showMessage("请选择需要删除的数据");
+    }
+};
+
+const saveFun = () => {
+    let cfg : any = [];
+
+    envInfo.value.environmentData.forEach((element: { name: string; path: string; description: string; }) => {
+        let item = {name: element.name, path: element.path, description: element.description};
+        cfg.push(item);
+    });
+    sendCommand("setSDKConfig", [cfg]);
+};
+
+const editFun = () => {
+    if (envInfo.value.selectRow != null) {
+        envInfo.value.addToolchain.name = envInfo.value.selectRow.name;
+        envInfo.value.addToolchain.path = envInfo.value.selectRow.path;
+        envInfo.value.addToolchain.description = envInfo.value.selectRow.description;
+
+        envInfo.value.editMode = true;
+        envInfo.value.dialogVisible = true;
+    }
+};
+
+const confirmFun = () => {
+    if (Object.values(envInfo.value.addToolchain).some((value) => value != null && value != '')) {
+        envInfo.value.dialogVisible = false;
+        if (envInfo.value.editMode) {
+            let index = envInfo.value.environmentData.indexOf(envInfo.value.selectRow);
+            envInfo.value.environmentData[index].name = envInfo.value.addToolchain.name;
+            envInfo.value.environmentData[index].path = envInfo.value.addToolchain.path;
+            envInfo.value.environmentData[index].description = envInfo.value.addToolchain.description;
+        }
+        else {
+            envInfo.value.environmentData.unshift(envInfo.value.addToolchain);
+        }
+        envInfo.value.editMode = false;
+    } else {
+        showMessage("请完善新增信息！");
+    }
+};
+
+let isInstalling = ref<boolean>(false);
+const installEnv = () => {
+    isInstalling.value = true;
+    setTimeout(() => {
+        isInstalling.value = false;
+    }, 3000);
+}
+
+const getToolChainFolderFunction = () => {
+    sendCommandData("browseToolchainFolder", envInfo.value.addToolchain.path);
+};
+
+const handleCurrentChange = (val: any) => {
+    envInfo.value.selectRow = val;
+};
+
+</script>
+<style scoped>
+@import "./index.less";
+</style>

--- a/src/vue/home/view/layout/index.less
+++ b/src/vue/home/view/layout/index.less
@@ -1,0 +1,76 @@
+.common-layout {
+
+    .header_box {
+        display: flex;
+        align-items: center;
+        background: #fff;
+        height: 86px;
+
+        .header_logo {
+            display: flex;
+            align-items: center;
+            column-gap: 12px;
+            font-size: 18px;
+            color: #333;
+
+            .logo_img {
+                width: 228px;
+                height: 68px;
+            }
+
+            .logo_text {
+                color: #333;
+                padding-top: 15px;
+
+                p {
+                    font-size: 18px;
+                }
+
+                span {
+                    font-size: 12px;
+                }
+            }
+        }
+
+    }
+
+    .el-aside {
+        width: 100%;
+        transition-property: all;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        transition-duration: 300ms;
+        background: #fff;
+        padding: 0 55px;
+        border-bottom: #E0E3EA 1px solid;
+
+        .el-menu-item {
+            color: #333;
+            background: #fff;
+
+            .title {
+                font-size: 14px;
+            }
+
+            &:hover {
+                background: #f2f3f5;
+            }
+
+            &.is-active {
+                background: #f2f3f5;
+                color: #165dff;
+            }
+        }
+
+    }
+
+    .container_main {
+        width: 100%;
+
+        .main_box {
+            width: 100%;
+            background: #fff;
+            padding: 14px 55px;
+        }
+
+    }
+}

--- a/src/vue/home/view/layout/index.vue
+++ b/src/vue/home/view/layout/index.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="common-layout">
+    <el-container>
+      <el-header class="header_box">
+        <div class="header_logo">
+          <img class="logo_img" :src="imgUrl['head-logo']" alt="" />
+          <div class="logo_text">
+            <p>扩展工具</p>
+            <span>v{{ extensionInfo.version }}</span>
+          </div>
+        </div>
+      </el-header>
+      <el-aside>
+        <el-menu
+          :collapse="isSidebarOpen"
+          :collapse-transition="false"
+          router
+          :default-active="$route.path"
+          background-color="#fff"
+          text-color="#333"
+          style="border: none"
+          mode="horizontal"
+        >
+          <el-menu-item
+            v-for="item in list"
+            :key="item.path"
+            :index="item.path"
+            :route="item.path"
+          >
+            <span class="title">{{ item.meta.title }}</span>
+          </el-menu-item>
+        </el-menu>
+      </el-aside>
+      <el-container class="container_main">
+        <el-main class="main_box">
+          <router-view></router-view>
+        </el-main>
+      </el-container>
+    </el-container>
+  </div>
+</template>
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { routes } from '../../router';
+import { extensionInfo } from '../../data';
+import { imgUrl } from '../../../assets/img'
+
+interface MenuRoute {
+  path: string
+  redirect?: string
+  children: any
+  meta: any
+}
+
+const isSidebarOpen = ref(false)
+type ListItemType = MenuRoute & { icon?: string }
+const list: any = computed(() => {
+  return getMenuList(routes)
+})
+
+const getMenuList = (list: MenuRoute[], basePath?: string): ListItemType[] => {
+  if (!list || list.length === 0) {
+    return []
+  }
+  list.sort((a, b) => {
+    return (a.meta?.orderNo || 0) - (b.meta?.orderNo || 0)
+  })
+  return list
+    .map((item) => {
+      const path =
+        basePath && !item.path.includes(basePath)
+          ? `${basePath}/${item.path}`
+          : item.path
+      return {
+        path,
+        title: item.meta?.title,
+        icon: item.meta?.icon,
+        children: getMenuList(item.children, path),
+        meta: item.meta,
+        redirect: item.redirect
+      }
+    })
+    .filter((item) => item.meta && item.meta.hidden !== true)
+}
+</script>
+
+<style scoped>
+@import './index.less';
+</style>

--- a/src/vue/home/view/symbolic-analysis/index.less
+++ b/src/vue/home/view/symbolic-analysis/index.less
@@ -1,0 +1,77 @@
+.content {
+    width: 100%;
+    height: 100%;
+
+    .body-box {
+        width: 80%;
+        min-width: 800px;
+
+        .el-form {
+            margin-bottom: 22px;
+            .file-box {
+                width: 0;
+            }
+            .el-form-item {
+                display: flex;
+                align-items: center;
+
+                .row-box {
+                    width: 100%;
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    column-gap: 20px;
+                }
+
+                :deep(.el-form-item__label) {
+                    justify-content: flex-start;
+                }
+            }
+        }
+
+        .el-input {
+            height: 40px;
+        }
+
+        .el-button {
+            width: 98px;
+            height: 40px;
+            margin: 0;
+        }
+
+        ul {
+            list-style: none;
+            display: flex;
+            width: 100%;
+            align-items: center;
+
+            li {
+                width: 160px;
+                height: 40px;
+                border: 1px solid #dcdfe6;
+                border-bottom: none;
+                text-align: center;
+                line-height: 40px;
+                cursor: pointer;
+                color: #333;
+                font-size: 14px;
+
+                &:hover {
+                    color: #1989FA;
+                }
+            }
+
+            .active {
+                color: #1989FA;
+            }
+        }
+
+        :deep(.el-table tr) {
+            height: 48px;
+        }
+
+        .el-table--fit {
+            border-top: 1px solid #DCDFE6;
+        }
+    }
+}

--- a/src/vue/home/view/symbolic-analysis/index.vue
+++ b/src/vue/home/view/symbolic-analysis/index.vue
@@ -1,0 +1,87 @@
+<template>
+    <div class="content">
+        <div class="body-box">
+            <el-form :model="analysisInfo" label-width="80">
+                <el-form-item label="map文件">
+                    <div class="row-box">
+                        <el-input v-model="analysisInfo.mapFileUrl" placeholder="请输入内容" />
+                        <el-button type="primary" plain @click="getFileFun"><input type="file" ref="fileInput"
+                                @change="handleFileChange" class="file-box" />浏览</el-button>
+                        <el-button type="primary" plain @click="readMapFun">分析</el-button>
+                    </div>
+                </el-form-item>
+            </el-form>
+            <ul>
+                <li v-for="(item, index) in analysisInfo.analysisTableList" :class="{ active: index === current }"
+                    :key="index" @click="tableChange(index)">
+                    {{ item.title }}
+                </li>
+            </ul>
+
+            <el-table v-loading="loading" element-loading-text="Loading..." :element-loading-spinner="svg"
+                element-loading-svg-view-box="-10, -10, 50, 50" class="loading_box"
+                :data="analysisInfo.analysisTableList[current].children" style="width: 100%">
+                <el-table-column v-for="item in analysisInfo.analysisTitleList" :key="item.title" :prop="item.field"
+                    :label="item.title" />
+            </el-table>
+        </div>
+    </div>
+</template>
+<script setup lang="ts">
+import { ref } from "vue";
+import { ElMessage } from "element-plus";
+import { analysisInfo } from '../../data';
+
+const loading = ref(false);
+const svg = `
+        <path class="path" d="
+          M 30 15
+          L 28 17
+          M 25.61 25.61
+          A 15 15, 0, 0, 1, 15 30
+          A 15 15, 0, 1, 1, 27.99 7.5
+          L 15 15
+        " style="stroke-width: 4px; fill: rgba(0, 0, 0, 0)"/>
+      `;
+const current = ref<number>(0);
+const tableChange = (index: number) => {
+    current.value = index;
+};
+const fileInput = ref<any>(null);
+const getFileFun = () => {
+    if (fileInput.value) {
+        fileInput.value.click();
+    }
+};
+const handleFileChange = (event: any) => {
+    const input = event.target;
+    if (!input.files || !input.files.length) return;
+    const file = input.files[0];
+    if (file.name.split(".").pop() !== "map") {
+        ElMessage.error("请选择.map文件");
+        return;
+    }
+    analysisInfo.value.mapFile = file;
+    if (URL && URL.createObjectURL) {
+        analysisInfo.value.mapFileUrl = file.name || URL.createObjectURL(file);
+    } else {
+        analysisInfo.value.mapFileUrl = "";
+    }
+};
+const readMapFun = () => {
+    const reader = new FileReader();
+    loading.value = true;
+    reader.onload = (e: any) => {
+        // 处理读取到的.map文件内容
+        const mapContent = e.target.result;
+        setTimeout(() => {
+            loading.value = false;
+        }, 5000);
+        // console.log(mapContent);
+    };
+    reader.readAsText(analysisInfo.value.mapFile);
+};
+</script>
+<style scoped>
+@import "./index.less";
+</style>

--- a/src/webviews/home.ts
+++ b/src/webviews/home.ts
@@ -1,13 +1,61 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { getEnvROOT, getExtensionVersion, installEnv, createProject, readJsonObject, openFolder, writeJsonObject, getBoardInfo } from '../api';
 
-let aboutViewPanel: vscode.WebviewPanel | null = null;
+let homeViewPanel: vscode.WebviewPanel | null = null;
 const name = "home";
 const title = "RT-Thread Home";
 
+const cfgFn = path.join(os.homedir(), '.env/cfg.json');
+const sdkCfgFn = path.join(os.homedir(), '.env/tools/scripts/sdk_cfg.json');
+
+let extensionInfo = {
+	version: "0.1.1",
+	env: {
+		path: "~/.env",
+		version: "0.0.1"
+	},
+	projectList: [
+		{
+			manufacturer: "ST",
+			boards: [
+				"stm32f412-st-nucleo",
+				"stm32f407-rt-spark"
+			]
+		},
+		{
+			manufacturer: "QEMU",
+			boards: [
+				"qemu-vexpress-a9",
+				"qemu-virt64-aarch64",
+				"qemu-virt64-riscv64"
+			]
+		}
+	],
+	SDKConfig : {},
+	configInfo : [{name: "RT-Thread", path: "d:/workspace/rt-thread", description: "RT-Thread主干路径"}]
+};
+
+function readReadmeFile(fn: string): string {
+	if (fs.existsSync(fn)) {
+		let data = fs.readFileSync(fn, 'utf-8');
+		return data;
+	}
+
+	return "";
+}
+
+function readBoardInfoFile() {
+    let bi = readJsonObject(path.join('resources', 'bi.json'));
+
+    return ;
+}
+
 export function openHomeWebview(context: vscode.ExtensionContext) {
-    if (aboutViewPanel) {
-        aboutViewPanel.reveal(vscode.ViewColumn.One);
+    if (homeViewPanel) {
+        homeViewPanel.reveal(vscode.ViewColumn.One);
     }
     else {
         const rootDir = path.join(context.extensionPath, 'out');
@@ -15,13 +63,36 @@ export function openHomeWebview(context: vscode.ExtensionContext) {
             enableScripts: true, // Enable javascript in the webview
             localResourceRoots: [vscode.Uri.file(rootDir)] // Only allow resources from vue view
         });
+        let localResourceRoots = vscode.Uri.joinPath(context.extensionUri, 'out').toString();
+        // console.log(localResourceRoots);
+
         const iconPath = path.join(context.extensionPath, 'resources', 'images', 'rt-thread.png');
         panel.iconPath = vscode.Uri.file(iconPath);
 
         // handle close webview event
         panel.onDidDispose(() => {
-            aboutViewPanel = null;
+            homeViewPanel = null;
         });
+
+        // update extensionInfo
+		extensionInfo.version = getExtensionVersion();
+		extensionInfo.env.path = path.join(os.homedir(), '.env');
+        // if .env/tools/script/env.json exist, to read the version of env script
+        if (fs.existsSync(path.join(extensionInfo.env.path, 'tools', 'scripts', 'env.json'))) {
+            let envInfo = readJsonObject(path.join(extensionInfo.env.path, 'tools', 'scripts', 'env.json'));
+            extensionInfo.env.version = envInfo.version;
+        }
+		extensionInfo.SDKConfig = readJsonObject(sdkCfgFn);
+        extensionInfo.projectList = getBoardInfo();
+        // console.log(extensionInfo.projectList);
+        // read RT-Thread folder
+        let cfg:any [] = readJsonObject(cfgFn);
+        if (cfg.length > 0) {
+            extensionInfo.configInfo[0].path = cfg[0].path;
+        }
+        else {
+            extensionInfo.configInfo[0].path = 'undefined';
+        }
 
         // read out/${name}/index.html
         const indexHtmlPath = vscode.Uri.file(context.asAbsolutePath(`out/${name}/index.html`));
@@ -37,9 +108,93 @@ export function openHomeWebview(context: vscode.ExtensionContext) {
                 return `"${panel.webview.asWebviewUri(vscode.Uri.file(absPath)).toString()}"`;
             });
         });
+        panel.webview.onDidReceiveMessage(async (message) => {
+            let data : any = {};
+            let defaultPath:any;
 
-        aboutViewPanel = panel;
+            switch (message.command) {
+                case 'getExtensionInfo':
+                    panel.webview.postMessage({command: 'extensionInfo', data: extensionInfo});
+                    return ;
+                case 'createProject':
+                    let projectInfo = message.args[0];
+                    createProject(projectInfo.folder, projectInfo);
+                    return;
+                case 'browseProjectFolder':
+                    defaultPath = message.args[0];
+                    let projectFolder = await openFolder(defaultPath);
+                    if (projectFolder) {
+                        panel.webview.postMessage({command: 'setProjectFolder', data: projectFolder});
+                    }
+                    return ;
+                case 'browseToolchainFolder':
+                    defaultPath = message.args[0];
+                    let folder = await openFolder(defaultPath);
+                    if (folder) {
+                        panel.webview.postMessage({command: 'setToolchainFolder', data: folder});
+                    }
+                    return;
+                case 'browseItemFolder':
+                    defaultPath = message.args[0];
+                    let itemFolder = await openFolder(defaultPath);
+                    if (itemFolder) {
+                        panel.webview.postMessage({command: 'setItemFolder', data: itemFolder});
+                    }
+                    return;
+
+                // configuration for toolchains
+                case 'getSDkConfig':
+                    data = readJsonObject(sdkCfgFn);
+                    if (data) {
+                        panel.webview.postMessage({command: 'setConfig', data: data});
+                    }
+                    return ;
+                case 'setSDKConfig':
+                    data = message.args[0];
+                    writeJsonObject(message.args[0], sdkCfgFn);
+    
+                    vscode.window.showInformationMessage('保存工具链配置成功');
+                    return ;
+    
+                // configuration for RT-Thread folder
+                case 'getConfig':
+                    data = readJsonObject(cfgFn);
+                    if (data) {
+                        panel.webview.postMessage({command: 'setConfig', data: data});
+                    }
+                    return ;
+                case 'setConfig':
+                    data = message.args[0];
+                    writeJsonObject(message.args[0], cfgFn);
+    
+                    vscode.window.showInformationMessage('保存路径配置成功');
+                    // update configData
+                    extensionInfo.configInfo[0].path = data[0].path;
+                    return ;
+
+                case 'getBoardReadme':
+                    data = message.args[0];
+                    let readme = readReadmeFile('d:/workspace/rt-thread/bsp/qemu-vexpress-a9/README.md');
+                    if (readme) {
+                        panel.webview.postMessage({command: 'setBoardReadme', data: readme});
+                    }
+    
+                    return ;
+                
+                case 'showMessage':
+                    data = message.args[0];
+                    vscode.window.showInformationMessage(data);
+                    return ;
+            }
+        }, undefined, context.subscriptions);
+        panel.onDidChangeViewState((e) => {
+            if (e.webviewPanel.visible) {
+                panel.webview.postMessage({command: 'extensionInfo', data: extensionInfo});
+            }
+        })
+    
+        homeViewPanel = panel;
     }
 
-    return aboutViewPanel;
+    return homeViewPanel;
 }


### PR DESCRIPTION
- 添加home vue页面；
  - 创建工程页，可以调用`scons`命令创建工程 <TODO: 后续需要添加创建完成后打开工程的提示>
  - 设置指定sdk工具链的路径，可以加入更多非gcc工具链（例如armclang，armcc，llvm，iar，tasking etc）
  - 设置RT-Thread目录功能（创建工程时基于这份RT-Thread代码）
- 梳理api.ts功能，更多共用功能都放置于api中；
- 修正当打开非rt-thread目录时侧边栏显示的问题（依然保证home页可以使用）；
