### PR TITLE
修复编译无法运行的问题，添加自动识别windows的env的功能

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "npm: compile"
 		}
 	]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,14 +9,3 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
-**/node_modules/**
-**/.git/**
-**/package-lock.json
-**/.DS_Store
-**/Thumbs.db
-**/*.log
-**/coverage/**
-**/dist/**
-**/.cache/**
-**/.temp/**
-**/.tmp/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,15 +7,13 @@
         "": {
             "name": "rt-thread-smart",
             "version": "0.4.11",
-            "workspaces": [
-                "src/vue"
-            ],
             "dependencies": {
                 "@vue/shared": "^3.x.x",
                 "element-plus": "^2.4.2",
                 "marked": "^14.1.3",
                 "vue": "^3.3.8",
-                "vue-router": "^4.5.0"
+                "vue-router": "^4.5.0",
+                "winreg": "^1.2.4"
             },
             "devDependencies": {
                 "@types/mocha": "^10.0.7",
@@ -4845,10 +4843,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/smart-vue": {
-            "resolved": "src/vue",
-            "link": true
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
@@ -5710,6 +5704,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/winreg": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.5.tgz",
+            "integrity": "sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmmirror.com/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5944,7 +5944,8 @@
         },
         "src/vue": {
             "name": "smart-vue",
-            "version": "0.0.1"
+            "version": "0.0.1",
+            "extraneous": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "repository": {
         "url": "https://github.com/RT-Thread/vscode-rt-smart"
     },
-    "workspaces": [
-        "src/vue"
-    ],
     "engines": {
         "vscode": "^1.96.0"
     },
@@ -173,7 +170,7 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",
-        "build:vue": "npm run build --workspace=smart-vue",
+        "build:vue": "cd src/vue && npm run build",
         "compile": "npm run build:vue && tsc -p ./",
         "watch": "tsc -watch -p ./",
         "pretest": "npm run compile && npm run lint",
@@ -185,7 +182,8 @@
         "element-plus": "^2.4.2",
         "marked": "^14.1.3",
         "vue": "^3.3.8",
-        "vue-router": "^4.5.0"
+        "vue-router": "^4.5.0",
+        "winreg": "^1.2.4"
     },
     "extensionDependencies": [
         "ms-python.python"

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,36 +1,99 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as os from 'os';
 import { getExtensionPath, isRTThreadWorksapce } from './api';
 import { Constants } from './constants';
 import { getCurrentProject } from './project/cmd';
 
 let _terminal: vscode.Terminal | undefined;
 
+const Registry = require('winreg');
+
 export function initTerminal() {
     let terminal = vscode.window.activeTerminal;
+
     if (terminal) {
         _terminal = terminal;
-        // change terminal name to RT-Thread
         let name = Constants.TERMINAL_LABLE;
         vscode.commands.executeCommand("workbench.action.terminal.renameWithArg", { name });
-    };
-}
+    }
 
-export function getTerminal(): vscode.Terminal | undefined {
-    if (!_terminal) {
-        let extensionPath = getExtensionPath();
-        if (extensionPath) {
-            let iconPath: vscode.Uri | vscode.ThemeIcon = vscode.Uri.file(path.join(extensionPath, 'resources', "images", "rt-thread.png"));
+    if (os.platform() === 'win32') {
+        const regKey = new Registry({
+            hive: Registry.HKCR,
+            key: '\\*\\shell\\ConEmu Here'
+        });
+        regKey.get('Icon', async function (err: any, item: any) {
+            if (!err && item && item.value) {
+                let conEmuPath = item.value.replace(/"/g, '').split(',')[0];
+                let conEmuDir = path.dirname(conEmuPath);
+                let conEmuBaseDir = path.join(conEmuDir, 'ConEmu');
+                let venvPath = path.join(conEmuDir, '..', '.venv');
+                venvPath = path.resolve(venvPath);
+
+                vscode.workspace.getConfiguration('terminal').update(
+                    'integrated.env.windows',
+                    { 'VIRTUAL_ENV': venvPath, 'PATH': `${venvPath}\\Scripts;${process.env.PATH}` },
+                    vscode.ConfigurationTarget.Workspace
+                );
+                let conEmuInitCmd = `cmd.exe /k ""${conEmuBaseDir}\\CmdInit.cmd" "${conEmuBaseDir}\\..\\..\\bin\\env-init.bat""`;
+
+                let terminal = vscode.window.activeTerminal;
+                if (terminal) {
+                    _terminal = terminal;
+                    vscode.commands.executeCommand("workbench.action.terminal.renameWithArg", { name: Constants.TERMINAL_LABLE });
+                    _terminal.sendText(conEmuInitCmd, true);
+                    _terminal.show();
+                }else{
+                    _terminal = terminal;
+                    let extensionPath = getExtensionPath();
+                    let iconPath: vscode.Uri | vscode.ThemeIcon | undefined;
+                    if (extensionPath) {
+                        iconPath = vscode.Uri.file(path.join(extensionPath, 'resources', "images", "rt-thread.png"));
+                    }
+                    const options: vscode.TerminalOptions = {
+                        name: Constants.TERMINAL_LABLE,
+                        iconPath: iconPath,
+                        message: Constants.TERMINAL_LOGO,
+                    };
+                    _terminal = vscode.window.createTerminal(options);
+                    _terminal.sendText(conEmuInitCmd, true);
+                    _terminal.show();
+                }
+            } else {
+                vscode.window.showErrorMessage('无法获取 ConEmu 路径，请确保已安装 ConEmu 并正确注册。');
+            }
+        });
+    }else {
+        let terminal = vscode.window.activeTerminal;
+        if (terminal) {
+            _terminal = terminal;
+            vscode.commands.executeCommand("workbench.action.terminal.renameWithArg", { name: Constants.TERMINAL_LABLE });
+            _terminal.show();
+        }else{
+            _terminal = terminal;
+            let extensionPath = getExtensionPath();
+            let iconPath: vscode.Uri | vscode.ThemeIcon | undefined;
+            if (extensionPath) {
+                iconPath = vscode.Uri.file(path.join(extensionPath, 'resources', "images", "rt-thread.png"));
+            }
             const options: vscode.TerminalOptions = {
                 name: Constants.TERMINAL_LABLE,
                 iconPath: iconPath,
                 message: Constants.TERMINAL_LOGO,
             };
-
             _terminal = vscode.window.createTerminal(options);
+            _terminal.show();
         }
     }
+}
+    
 
+
+export function getTerminal(): vscode.Terminal | undefined {
+    if (!_terminal) {
+        initTerminal()
+    }
     return _terminal;
 }
 


### PR DESCRIPTION
修复问题：
当打包成拓展运行的时候会报以下错误
<img width="408" height="78" alt="image" src="https://github.com/user-attachments/assets/6866a59a-6cc3-4e2d-a156-05aeba29bcfc" />
<img width="381" height="153" alt="image" src="https://github.com/user-attachments/assets/ce9ac2ef-2563-4291-b9a4-5fee850316e3" />

添加功能：
根据注册表自动识别env路径，并在用户使用cmd的时候将环境应用到终端上:
如下图所示
<img width="868" height="388" alt="image" src="https://github.com/user-attachments/assets/c8788ad7-be05-492f-8d5e-01653dfc628e" />
